### PR TITLE
Supporting addition of links at target specified from options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_conte
 
 This plugin specifically targets fonts used with the application which are bundled using webpack. The plugin would add `<link>` tags in the begining of `<head>` of your html:
 ```html
-<link rel="preload" href="/font1.woff" as="font" crossorigin="">
-<link rel="preload" href="/font2.woff" as="font" crossorigin="">
+<link rel="preload" href="/font1.woff" as="font" crossorigin>
+<link rel="preload" href="/font2.woff" as="font" crossorigin>
 ```
 
 ## Getting Started
@@ -36,7 +36,7 @@ And run `webpack` via your preferred method.
 
 ## Options
 
-### `indexFile`
+### `index`
 
 Type: `String`
 Default: `index.html`
@@ -46,7 +46,7 @@ Name of the index file which needs modification.
 ```js
 // in your webpack.config.js
 new FontPreloadPlugin({
-  indexFile: 'index.html',
+  index: 'index.html',
 });
 ```
 
@@ -89,6 +89,21 @@ Type of load. It can be either `preload` or `prefetch`.
 // in your webpack.config.js
 new FontPreloadPlugin({
   loadType: 'preload',
+});
+```
+
+### `insertAfter`
+
+Type: `String`
+Default: `head > title`
+
+The selector for node before which the preload/prefetch links should be added.
+
+```js
+// in your webpack.config.js
+new FontPreloadPlugin({
+  // Add the preload statements before any other <link> tag present in html
+  insertAfter: 'head > link:nth-child(1)',
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ new FontPreloadPlugin({
 });
 ```
 
-### `insertAfter`
+### `insertBefore`
 
 Type: `String`
 Default: `head > title`
@@ -103,7 +103,7 @@ The selector for node before which the preload/prefetch links should be added.
 // in your webpack.config.js
 new FontPreloadPlugin({
   // Add the preload statements before any other <link> tag present in html
-  insertAfter: 'head > link:nth-child(1)',
+  insertBefore: 'head > link:nth-child(1)',
 });
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ class WebpackFontPreloadPlugin {
   constructor(options) {
     const defaults = {
       // Name of the index file which needs modification
-      indexFile: 'index.html',
+      index: 'index.html',
 
       // Default font extensions which should be used
       extensions: ['woff', 'ttf', 'eot'],
@@ -15,6 +15,10 @@ class WebpackFontPreloadPlugin {
 
       // Type of load. It can be either "preload" or "prefetch"
       loadType: 'preload',
+
+      // String representing the selector of tag after which the <link>
+      // tags would be inserted.
+      insertAfter: 'head > title',
     };
     this.options = { ...defaults, ...options };
   }
@@ -38,7 +42,7 @@ class WebpackFontPreloadPlugin {
     try {
       const { assets, outputOptions } = compilation;
       const assetNames = assets && (Object.keys(assets) || []);
-      const index = assets[this.options.indexFile];
+      const index = assets[this.options.index];
       const indexSource = index && index.source();
       const publicPath = outputOptions && outputOptions.publicPath;
       if (indexSource) {
@@ -48,7 +52,7 @@ class WebpackFontPreloadPlugin {
             strLink += this.getLinkTag(asset, publicPath);
           }
         });
-        assets[this.options.indexFile] = new RawSource(this.appendLinks(indexSource, strLink));
+        assets[this.options.index] = new RawSource(this.appendLinks(indexSource, strLink));
       }
     } catch (error) {
       return callback(error);
@@ -69,8 +73,20 @@ class WebpackFontPreloadPlugin {
     const parsed = new JSDOM(html);
     const { document } = parsed && parsed.window;
     const head = document && document.getElementsByTagName('head')[0];
+    const insertAfterTag = document && document.querySelector(this.options.insertAfter);
     if (head) {
-      head.innerHTML = `${links}${head.innerHTML.trim()}`;
+      if (!insertAfterTag) {
+        // The `insertAfterTag` is not present. Prepend to head itself.
+        head.innerHTML = `${links}${head.innerHTML.trim()}`;
+      } else {
+        const parent = insertAfterTag.parentNode;
+        const newNodes = this.createNodeFromHtml(document, links);
+        if (newNodes && newNodes.length > 0) {
+          newNodes.forEach(n => {
+            parent.insertBefore(n, insertAfterTag);
+          });
+        }
+      }
       return parsed.serialize();
     }
     return html;
@@ -117,6 +133,18 @@ class WebpackFontPreloadPlugin {
     return this.options.extensions.includes(
       this.getExtension(name),
     );
+  }
+
+  /**
+   * Generate nodes/element from the Html string
+   * @param {Object} document Document object from jsdom
+   * @param {String} strHtml String representing the html
+   * @returns {Array} Array of html nodes
+   */
+  createNodeFromHtml(document, strHtml) {
+    const container = document.createElement('div');
+    container.innerHTML = strHtml.trim();
+    return container.childNodes;
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,9 @@ class WebpackFontPreloadPlugin {
       // Type of load. It can be either "preload" or "prefetch"
       loadType: 'preload',
 
-      // String representing the selector of tag after which the <link>
+      // String representing the selector of tag before which the <link>
       // tags would be inserted.
-      insertAfter: 'head > title',
+      insertBefore: 'head > title',
     };
     this.options = { ...defaults, ...options };
   }
@@ -73,17 +73,17 @@ class WebpackFontPreloadPlugin {
     const parsed = new JSDOM(html);
     const { document } = parsed && parsed.window;
     const head = document && document.getElementsByTagName('head')[0];
-    const insertAfterTag = document && document.querySelector(this.options.insertAfter);
+    const insertBeforeTag = document && document.querySelector(this.options.insertBefore);
     if (head) {
-      if (!insertAfterTag) {
-        // The `insertAfterTag` is not present. Prepend to head itself.
+      if (!insertBeforeTag) {
+        // The `insertBeforeTag` is not present. Prepend to head itself.
         head.innerHTML = `${links}${head.innerHTML.trim()}`;
       } else {
-        const parent = insertAfterTag.parentNode;
+        const parent = insertBeforeTag.parentNode;
         const newNodes = this.createNodeFromHtml(document, links);
         if (newNodes && newNodes.length > 0) {
-          newNodes.forEach(n => {
-            parent.insertBefore(n, insertAfterTag);
+          newNodes.forEach((n) => {
+            parent.insertBefore(n, insertBeforeTag);
           });
         }
       }


### PR DESCRIPTION
Fixing #2.
The option `insertBefore` can be used to specify the place at which `<link>` would be added. 