### PR TITLE
Extending `replaceCallback` capabilities

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -16,6 +16,11 @@ export interface ReplaceCallbackOptions {
    * `<link>` tags for preloading fonts as a string
    */
   linksAsString: string;
+
+  /**
+   * `<link>` tags for preloading fonts as an array of strings
+   */
+  linksAsArray: string[];
 }
 
 /**
@@ -81,6 +86,7 @@ export interface PluginOptions {
   replaceCallback?: ({
     indexSource,
     linksAsString,
+    linksAsArray,
   }: ReplaceCallbackOptions) => string;
 
   /**

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -21,6 +21,11 @@ export interface ReplaceCallbackOptions {
    * `<link>` tags for preloading fonts as an array of strings
    */
   linksAsArray: string[];
+
+  /**
+   * Link data for building a `<link>` tag
+   */
+  linksAsStructuredData: LinkData[];
 }
 
 /**
@@ -87,6 +92,7 @@ export interface PluginOptions {
     indexSource,
     linksAsString,
     linksAsArray,
+    linksAsStructuredData,
   }: ReplaceCallbackOptions) => string;
 
   /**
@@ -101,4 +107,28 @@ export interface PluginOptions {
    * Defaults to undefined.
    */
   filter?: string | RegExp;
+}
+
+/**
+ * Data to build <font> link.
+ */
+export interface LinkData {
+  /**
+   * Is the font request crossorigin or not.
+   *
+   * Defaults to true.
+   */
+  crossorigin: PluginOptions["crossorigin"];
+
+  /**
+   * Type of load. It can be either "preload" or "prefetch".
+   *
+   * Defaults to "preload".
+   */
+  loadType: PluginOptions["loadType"];
+
+  /**
+   * Final value of href attribute of the <link>.
+   */
+  href: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,13 @@ export default class WebpackFontPreloadPlugin {
         const publicPath = (outputOptions && outputOptions.publicPath) || "";
         if (indexSource) {
           let strLink = "";
+          const linksAsArray: string[] = [];
           assets.forEach((asset) => {
             if (this.isFontAsset(asset.name) && this.isFiltered(asset.name)) {
               strLink += this.getLinkTag(asset.name, publicPath.toString());
+              linksAsArray.push(
+                this.getLinkTag(asset.name, publicPath.toString())
+              );
             }
           });
           // If `replaceCallback` is specified then app is responsible to forming the updated
@@ -80,6 +84,7 @@ export default class WebpackFontPreloadPlugin {
               this.options.replaceCallback({
                 indexSource: indexSource.toString(),
                 linksAsString: strLink,
+                linksAsArray,
               })
             );
           } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { JSDOM } from "jsdom";
 import fs from "fs";
 import path from "path";
 import { Compiler, Compilation } from "webpack";
-import { Callback, LoadType, PluginOptions } from "./Types";
+import { Callback, LinkData, LoadType, PluginOptions } from "./Types";
 
 export default class WebpackFontPreloadPlugin {
   private options: PluginOptions;
@@ -68,11 +68,15 @@ export default class WebpackFontPreloadPlugin {
         if (indexSource) {
           let strLink = "";
           const linksAsArray: string[] = [];
+          const linksAsStructuredData: LinkData[] = [];
           assets.forEach((asset) => {
             if (this.isFontAsset(asset.name) && this.isFiltered(asset.name)) {
               strLink += this.getLinkTag(asset.name, publicPath.toString());
               linksAsArray.push(
                 this.getLinkTag(asset.name, publicPath.toString())
+              );
+              linksAsStructuredData.push(
+                this.getLinkData(asset.name, publicPath.toString())
               );
             }
           });
@@ -85,6 +89,7 @@ export default class WebpackFontPreloadPlugin {
                 indexSource: indexSource.toString(),
                 linksAsString: strLink,
                 linksAsArray,
+                linksAsStructuredData,
               })
             );
           } else {
@@ -165,6 +170,20 @@ export default class WebpackFontPreloadPlugin {
       as="font"
       ${crossorigin ? "crossorigin" : ""}
     >`;
+  }
+
+  /**
+   * Get all the necesarry data for building of a `<link>` tag for provided name
+   * and public path.
+   *
+   * @param {string} name Name of the font asset
+   * @param {string} publicPath Public path from webpack configuration
+   * @returns {LinkData} Structured data of the link
+   *
+   */
+  private getLinkData(name: string, publicPath: string): LinkData {
+    const { crossorigin, loadType } = this.options;
+    return { crossorigin, loadType, href: `${publicPath}${name}` };
   }
 
   /**

--- a/test/utils/TestUtil.ts
+++ b/test/utils/TestUtil.ts
@@ -161,7 +161,7 @@ export function areValidFonts(
   validExtensions: string[]
 ): Promise<true | string[]> {
   const expression = /(?:\.([^.]+))?$/;
-  const errors = [];
+  const errors: string[] = [];
   if (fonts.length === 0) {
     return Promise.reject(["No font's are preloaded in the output."]);
   }


### PR DESCRIPTION
This PR resolves this issue: https://github.com/sn-satyendra/webpack-font-preload-plugin/issues/54